### PR TITLE
Workarround python-coveralls issue with pytest-cov version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ hypothesis[datetime]
 logassert
 mock
 pytest
-pytest-cov
+pytest-cov==2.5.0
 requests>=2.9.1
 sgp4>=1.4


### PR DESCRIPTION
Explicit version of pytest-cov to workarround this issue: https://github.com/z4r/python-coveralls/issues/66