### PR TITLE
Clarify current pass might be returned

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 # orbit-predictor changelog
 
+## 1.9.1 (2019-04-14)
+
+* Fix trivial import error in deprecated module
+
 ## 1.9.0 (2019-04-12)
 
 * First Python-3 only release!

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -179,10 +179,13 @@ class CartesianPredictor(Predictor):
                       aos_at_dg=0, limit_date=None):
         """Return a PredictedPass instance with the data of the next pass over the given location
 
-        locattion_llh: point on Earth we want to see from the satellite.
-        when_utc: datetime UTC.
-        max_elevation_gt: filter passings with max_elevation under it.
+        location_llh: point on Earth we want to see from the satellite.
+        when_utc: datetime UTC after which the pass is calculated, default to now.
+        max_elevation_gt: filter passes with max_elevation under it.
         aos_at_dg: This is if we want to start the pass at a specific elevation.
+
+        The next pass with a LOS strictly after when_utc will be returned,
+        possibly the current pass.
         """
         if when_utc is None:
             when_utc = dt.datetime.utcnow()

--- a/tests/test_tle_predictor.py
+++ b/tests/test_tle_predictor.py
@@ -156,7 +156,7 @@ class TLEPredictorTestCase(unittest.TestCase):
             limit_date=pass_.los + dt.timedelta(seconds=1))
         self.assertEqual(pass_, new_pass)
 
-    def test_get_next_pass_while_passing(self):
+    def test_get_next_pass_right_at_passing(self):
         date = dt.datetime.strptime("2014/10/23 01:27:33.224", '%Y/%m/%d %H:%M:%S.%f')
         pass_ = self.predictor.get_next_pass(ARG, date)
         self.assertAlmostEqual(pass_.aos, date, delta=ONE_SECOND)
@@ -164,6 +164,12 @@ class TLEPredictorTestCase(unittest.TestCase):
 
         position = self.predictor.get_position(date)
         self.assertTrue(ARG.is_visible(position))
+
+    def test_get_next_pass_while_passing_gets_current(self):
+        date = dt.datetime.strptime("2014/10/23 01:28:00.000", '%Y/%m/%d %H:%M:%S.%f')
+        pass_ = self.predictor.get_next_pass(ARG, date)
+
+        self.assertTrue(pass_.aos < date < pass_.los)
 
     def test_greater_than_deg(self):
         date = dt.datetime.strptime("2014/10/23 01:25:09", '%Y/%m/%d %H:%M:%S')


### PR DESCRIPTION
Rather than a "solution" to #48, this is a clarification that it's the expected result.

Conflicts with https://github.com/satellogic/orbit-predictor/pull/50.