### PR TITLE
Never return current pass

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 # orbit-predictor changelog
 
+## 1.9.1 (2019-04-14)
+
+* Fix trivial import error in deprecated module
+
 ## 1.9.0 (2019-04-12)
 
 * First Python-3 only release!

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -179,10 +179,13 @@ class CartesianPredictor(Predictor):
                       aos_at_dg=0, limit_date=None):
         """Return a PredictedPass instance with the data of the next pass over the given location
 
-        locattion_llh: point on Earth we want to see from the satellite.
-        when_utc: datetime UTC.
-        max_elevation_gt: filter passings with max_elevation under it.
+        location_llh: point on Earth we want to see from the satellite.
+        when_utc: datetime UTC after which the pass is calculated, default to now.
+        max_elevation_gt: filter passes with max_elevation under it.
         aos_at_dg: This is if we want to start the pass at a specific elevation.
+
+        The next pass with an AOS equal or strictly after when_utc will be returned,
+        never the current pass.
         """
         if when_utc is None:
             when_utc = dt.datetime.utcnow()
@@ -226,7 +229,9 @@ class LocationPredictor:
                 if pass_.valid:
                     if self.limit_date is not None and pass_.aos > self.limit_date:
                         break
-                    yield self._build_predicted_pass(pass_)
+                    elif pass_.aos > self.start_date:
+                        # Only yields the pass if the AOS is *after* the start date
+                        yield self._build_predicted_pass(pass_)
 
                 if self.limit_date is not None and current_date > self.limit_date:
                     break

--- a/tests/test_tle_predictor.py
+++ b/tests/test_tle_predictor.py
@@ -156,7 +156,7 @@ class TLEPredictorTestCase(unittest.TestCase):
             limit_date=pass_.los + dt.timedelta(seconds=1))
         self.assertEqual(pass_, new_pass)
 
-    def test_get_next_pass_while_passing(self):
+    def test_get_next_pass_right_at_passing(self):
         date = dt.datetime.strptime("2014/10/23 01:27:33.224", '%Y/%m/%d %H:%M:%S.%f')
         pass_ = self.predictor.get_next_pass(ARG, date)
         self.assertAlmostEqual(pass_.aos, date, delta=ONE_SECOND)
@@ -164,6 +164,12 @@ class TLEPredictorTestCase(unittest.TestCase):
 
         position = self.predictor.get_position(date)
         self.assertTrue(ARG.is_visible(position))
+
+    def test_get_next_pass_while_passing_gets_next(self):
+        date = dt.datetime.strptime("2014/10/23 01:28:00.000", '%Y/%m/%d %H:%M:%S.%f')
+        pass_ = self.predictor.get_next_pass(ARG, date)
+
+        self.assertTrue(date < pass_.aos < pass_.los)
 
     def test_greater_than_deg(self):
         date = dt.datetime.strptime("2014/10/23 01:25:09", '%Y/%m/%d %H:%M:%S')


### PR DESCRIPTION
This is a "solution" to #48 by changing the current semantics of `when_utc` in `get_next_pass` and updating the documentation accordingly.

Conflicts with #49.