### PR TITLE
New location predictor

### DIFF
--- a/orbit_predictor/predictors/_minimize.py
+++ b/orbit_predictor/predictors/_minimize.py
@@ -1,6 +1,8 @@
-from math import sqrt, inf, copysign, isnan
+from math import sqrt, copysign, isnan
 
 from scipy.optimize.optimize import OptimizeResult, _status_message
+
+inf = float("inf")
 
 
 def minimize_scalar_bounded_alt(func, bounds, xatol=1e-5, maxiter=500, **extra):

--- a/orbit_predictor/predictors/_minimize.py
+++ b/orbit_predictor/predictors/_minimize.py
@@ -1,0 +1,109 @@
+from math import sqrt, inf, copysign, isnan
+
+from scipy.optimize.optimize import OptimizeResult, _status_message
+
+
+def minimize_scalar_bounded_alt(func, bounds, xatol=1e-5, maxiter=500, **extra):
+    # Adapted from
+    # https://github.com/scipy/scipy/blob/v1.5.2/scipy/optimize/optimize.py
+    maxfun = maxiter
+    x1, x2 = bounds
+    assert x1 <= x2
+
+    flag = 0
+
+    sqrt_eps = sqrt(2.2e-16)
+    golden_mean = 0.5 * (3.0 - sqrt(5.0))
+    a, b = x1, x2
+    fulc = a + golden_mean * (b - a)
+    nfc, xf = fulc, fulc
+    rat = e = 0.0
+    x = xf
+    fx = func(x)
+    num = 1
+    fu = inf
+
+    ffulc = fnfc = fx
+    xm = 0.5 * (a + b)
+    tol1 = sqrt_eps * abs(xf) + xatol / 3.0
+    tol2 = 2.0 * tol1
+
+    while abs(xf - xm) > (tol2 - 0.5 * (b - a)):
+        golden = 1
+        # Check for parabolic fit
+        if abs(e) > tol1:
+            golden = 0
+            r = (xf - nfc) * (fx - ffulc)
+            q = (xf - fulc) * (fx - fnfc)
+            p = (xf - fulc) * q - (xf - nfc) * r
+            q = 2.0 * (q - r)
+            if q > 0.0:
+                p = -p
+            q = abs(q)
+            r = e
+            e = rat
+
+            # Check for acceptability of parabola
+            if ((abs(p) < abs(0.5*q*r)) and (p > q*(a - xf)) and
+                    (p < q * (b - xf))):
+                rat = (p + 0.0) / q
+                x = xf + rat
+
+                if ((x - a) < tol2) or ((b - x) < tol2):
+                    si = copysign(1, xm - xf) + ((xm - xf) == 0)
+                    rat = tol1 * si
+            else:      # do a golden-section step
+                golden = 1
+
+        if golden:  # do a golden-section step
+            if xf >= xm:
+                e = a - xf
+            else:
+                e = b - xf
+            rat = golden_mean*e
+
+        si = copysign(1, rat) + (rat == 0)
+        x = xf + si * max(abs(rat), tol1)
+        fu = func(x)
+        num += 1
+
+        if fu <= fx:
+            if x >= xf:
+                a = xf
+            else:
+                b = xf
+            fulc, ffulc = nfc, fnfc
+            nfc, fnfc = xf, fx
+            xf, fx = x, fu
+        else:
+            if x < xf:
+                a = x
+            else:
+                b = x
+            if (fu <= fnfc) or (nfc == xf):
+                fulc, ffulc = nfc, fnfc
+                nfc, fnfc = x, fu
+            elif (fu <= ffulc) or (fulc == xf) or (fulc == nfc):
+                fulc, ffulc = x, fu
+
+        xm = 0.5 * (a + b)
+        tol1 = sqrt_eps * abs(xf) + xatol / 3.0
+        tol2 = 2.0 * tol1
+
+        if num >= maxfun:
+            flag = 1
+            break
+
+    if isnan(xf) or isnan(fx) or isnan(fu):
+        flag = 2
+
+    fval = fx
+
+    result = OptimizeResult(fun=fval, status=flag, success=(flag == 0),
+                            message={0: 'Solution found.',
+                                     1: 'Maximum number of function calls '
+                                        'reached.',
+                                     2: _status_message['nan']}.get(flag, ''),
+                            x=xf, nfev=num)
+
+    return result

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -188,13 +188,13 @@ class CartesianPredictor(Predictor):
         return eclipse_duration(beta, self.period)
 
     def passes_over(self, location, when_utc, limit_date=None, max_elevation_gt=0, aos_at_dg=0,
-                    location_predictor_class=LocationPredictor):
+                    location_predictor_class=LocationPredictor, tolerance_s=1.0):
         return location_predictor_class(location, self, when_utc, limit_date,
-                                        max_elevation_gt, aos_at_dg)
+                                        max_elevation_gt, aos_at_dg, tolerance_s=tolerance_s)
 
     def get_next_pass(self, location, when_utc=None, max_elevation_gt=5,
                       aos_at_dg=0, limit_date=None,
-                      location_predictor_class=LocationPredictor):
+                      location_predictor_class=LocationPredictor, tolerance_s=1.0):
         """Return a PredictedPass instance with the data of the next pass over the given location
 
         location_llh: point on Earth we want to see from the satellite.
@@ -211,7 +211,8 @@ class CartesianPredictor(Predictor):
         for pass_ in self.passes_over(location, when_utc, limit_date,
                                       max_elevation_gt=max_elevation_gt,
                                       aos_at_dg=aos_at_dg,
-                                      location_predictor_class=location_predictor_class):
+                                      location_predictor_class=location_predictor_class,
+                                      tolerance_s=tolerance_s):
             return pass_
         else:
             raise NotReachable('Propagation limit date exceeded')

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -24,7 +24,7 @@ import datetime as dt
 import logging
 import warnings
 from collections import namedtuple
-from math import pi, acos, degrees, radians
+from math import pi, degrees
 
 import numpy as np
 try:
@@ -34,21 +34,23 @@ except ImportError:
                   ImportWarning)
 
 from orbit_predictor.constants import MU_E
-from orbit_predictor.exceptions import NotReachable, PropagationError
+from orbit_predictor.exceptions import NotReachable
 from orbit_predictor import coordinate_systems
 from orbit_predictor.keplerian import rv2coe
 from orbit_predictor.utils import (
     angle_between,
-    cross_product,
-    dot_product,
     reify,
-    vector_diff,
     vector_norm,
     gstime_from_datetime,
     get_shadow,
     get_sun,
     eclipse_duration,
     get_satellite_minus_penumbra_verticals,
+)
+
+from .pass_iterators import (  # noqa: F401
+    LocationPredictor,
+    PredictedPass,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,81 +92,6 @@ class Position(namedtuple(
         sma = p / (1 - ecc ** 2)
 
         return sma, ecc, degrees(inc), degrees(raan), degrees(argp), degrees(ta)
-
-
-class PredictedPass:
-    def __init__(self, location, sate_id,
-                 max_elevation_deg,
-                 aos, los, duration_s,
-                 max_elevation_position=None,
-                 max_elevation_date=None):
-        self.location = location
-        self.sate_id = sate_id
-        self.max_elevation_position = max_elevation_position
-        self.max_elevation_date = max_elevation_date
-        self.max_elevation_deg = max_elevation_deg
-        self.aos = aos
-        self.los = los
-        self.duration_s = duration_s
-
-    @property
-    def midpoint(self):
-        """Returns a datetime of the midpoint of the pass"""
-        return self.aos + (self.los - self.aos) / 2
-
-    def __repr__(self):
-        return "<PredictedPass {} over {} on {}>".format(self.sate_id, self.location, self.aos)
-
-    def __eq__(self, other):
-        return all([issubclass(other.__class__, PredictedPass),
-                    self.location == other.location,
-                    self.sate_id == other.sate_id,
-                    self.max_elevation_position == other.max_elevation_position,
-                    self.max_elevation_date == other.max_elevation_date,
-                    self.max_elevation_deg == other.max_elevation_deg,
-                    self.aos == other.aos,
-                    self.los == other.los,
-                    self.duration_s == other.duration_s])
-
-    def get_off_nadir_angle(self):
-        warnings.warn("This method is deprecated!", DeprecationWarning)
-        return self.off_nadir_deg
-
-    @reify
-    def off_nadir_deg(self):
-        """Computes off-nadir angle calculation
-
-        Given satellite position ``sate_pos``, velocity ``sate_vel``, and
-        location ``target`` in a common frame, off-nadir angle ``off_nadir_angle``
-        is given by:
-            t2b = sate_pos - target
-            cos(off_nadir_angle) =     (sate_pos  · t2b)     # Vectorial dot product
-                                    _______________________
-                                    || sate_pos || || t2b||
-
-        Sign for the rotation is calculated this way
-
-        cross = target ⨯ sate_pos
-        sign =   cross · sate_vel
-               ____________________
-               | cross · sate_vel |
-        """
-        sate_pos = self.max_elevation_position.position_ecef
-        sate_vel = self.max_elevation_position.velocity_ecef
-        target = self.location.position_ecef
-        t2b = vector_diff(sate_pos, target)
-        angle = acos(
-            dot_product(sate_pos, t2b) / (vector_norm(sate_pos) * vector_norm(t2b))
-        )
-
-        cross = cross_product(target, sate_pos)
-        dot = dot_product(cross, sate_vel)
-        try:
-            sign = dot / abs(dot)
-        except ZeroDivisionError:
-            sign = 1
-
-        return degrees(angle) * sign
 
 
 class Predictor:
@@ -357,182 +284,3 @@ class CartesianPredictor(Predictor):
 
 class GPSPredictor(Predictor):
     pass
-
-
-class LocationPredictor:
-    """Predicts passes over a given location
-    Exposes an iterable interface
-    """
-
-    def __init__(self, location, predictor, start_date, limit_date=None,
-                 max_elevation_gt=0, aos_at_dg=0):
-        self.location = location
-        self.predictor = predictor
-        self.start_date = start_date
-        self.limit_date = limit_date
-
-        self.max_elevation_gt = radians(max([max_elevation_gt, aos_at_dg]))
-        self.aos_at = radians(aos_at_dg)
-
-    def __iter__(self):
-        """Returns one pass each time"""
-        current_date = self.start_date
-        while True:
-            if self.is_ascending(current_date):
-                # we need a descending point
-                ascending_date = current_date
-                descending_date = self._find_nearest_descending(ascending_date)
-                pass_ = self._refine_pass(ascending_date, descending_date)
-                if pass_.valid:
-                    if self.limit_date is not None and pass_.aos > self.limit_date:
-                        break
-                    yield self._build_predicted_pass(pass_)
-
-                if self.limit_date is not None and current_date > self.limit_date:
-                    break
-
-                current_date = pass_.tca + self._orbit_step(0.6)
-
-            else:
-                current_date = self._find_nearest_ascending(current_date)
-
-    def _build_predicted_pass(self, accuratepass):
-        """Returns a classic predicted pass"""
-        tca_position = self.predictor.get_position(accuratepass.tca)
-
-        return PredictedPass(self.location, self.predictor.sate_id,
-                             max_elevation_deg=accuratepass.max_elevation_deg,
-                             aos=accuratepass.aos,
-                             los=accuratepass.los,
-                             duration_s=accuratepass.duration.total_seconds(),
-                             max_elevation_position=tca_position,
-                             max_elevation_date=accuratepass.tca,
-                             )
-
-    def _find_nearest_descending(self, ascending_date):
-        for candidate in self._sample_points(ascending_date):
-            if not self.is_ascending(candidate):
-                return candidate
-        else:
-            logger.error('Could not find a descending pass over %s start date: %s - TLE: %s',
-                         self.location, ascending_date, self.predictor.tle)
-            raise PropagationError("Can not find an descending phase")
-
-    def _find_nearest_ascending(self, descending_date):
-        for candidate in self._sample_points(descending_date):
-            if self.is_ascending(candidate):
-                return candidate
-        else:
-            logger.error('Could not find an ascending pass over %s start date: %s - TLE: %s',
-                         self.location, descending_date, self.predictor.tle)
-            raise PropagationError('Can not find an ascending phase')
-
-    def _sample_points(self, date):
-        """Helper method to found ascending or descending phases of elevation"""
-        start = date
-        end = date + self._orbit_step(0.99)
-        mid = self.midpoint(start, end)
-        mid_right = self.midpoint(mid, end)
-        mid_left = self.midpoint(start, mid)
-
-        return [end, mid, mid_right, mid_left]
-
-    def _refine_pass(self, ascending_date, descending_date):
-        tca = self._find_tca(ascending_date, descending_date)
-        elevation = self._elevation_at(tca)
-
-        if elevation > self.max_elevation_gt:
-            aos = self._find_aos(tca)
-            los = self._find_los(tca)
-        else:
-            aos = los = None
-
-        return AccuratePredictedPass(aos, tca, los, elevation)
-
-    def _find_tca(self, ascending_date, descending_date):
-        while not self._precision_reached(ascending_date, descending_date):
-            midpoint = self.midpoint(ascending_date, descending_date)
-            if self.is_ascending(midpoint):
-                ascending_date = midpoint
-            else:
-                descending_date = midpoint
-
-        return ascending_date
-
-    def _precision_reached(self, start, end):
-        # TODO: Allow the precision to change from the outside
-        return end - start <= ONE_SECOND
-
-    @staticmethod
-    def midpoint(start, end):
-        """Returns the midpoint between two dates"""
-        return start + (end - start) / 2
-
-    def _elevation_at(self, when_utc):
-        position = self.predictor.get_only_position(when_utc)
-        return self.location.elevation_for(position)
-
-    def is_passing(self, when_utc):
-        """Returns a boolean indicating if satellite is actually visible"""
-        return bool(self._elevation_at(when_utc))
-
-    def is_ascending(self, when_utc):
-        """Check is elevation is ascending or descending on a given point"""
-        elevation = self._elevation_at(when_utc)
-        next_elevation = self._elevation_at(when_utc + ONE_SECOND)
-        return elevation <= next_elevation
-
-    def _orbit_step(self, size):
-        """Returns a time step, that will make the satellite advance a given number of orbits"""
-        step_in_radians = size * 2 * pi
-        seconds = (step_in_radians / self.predictor.mean_motion) * 60
-        return dt.timedelta(seconds=seconds)
-
-    def _find_aos(self, tca):
-        end = tca
-        start = tca - self._orbit_step(0.34)  # On third of the orbit
-        elevation = self._elevation_at(start)
-        assert elevation < 0
-        while not self._precision_reached(start, end):
-            midpoint = self.midpoint(start, end)
-            elevation = self._elevation_at(midpoint)
-            if elevation < self.aos_at:
-                start = midpoint
-            else:
-                end = midpoint
-        return end
-
-    def _find_los(self, tca):
-        start = tca
-        end = tca + self._orbit_step(0.34)
-        while not self._precision_reached(start, end):
-            midpoint = self.midpoint(start, end)
-            elevation = self._elevation_at(midpoint)
-
-            if elevation < self.aos_at:
-                end = midpoint
-            else:
-                start = midpoint
-
-        return start
-
-
-class AccuratePredictedPass:
-
-    def __init__(self, aos, tca, los, max_elevation):
-        self.aos = round_datetime(aos) if aos is not None else None
-        self.tca = round_datetime(tca)
-        self.los = round_datetime(los) if los is not None else None
-        self.max_elevation = max_elevation
-
-    @property
-    def valid(self):
-        return self.max_elevation > 0 and self.aos is not None and self.los is not None
-
-    @reify
-    def max_elevation_deg(self):
-        return degrees(self.max_elevation)
-
-    @reify
-    def duration(self):
-        return self.los - self.aos

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -187,12 +187,14 @@ class CartesianPredictor(Predictor):
         beta = self.get_beta(when_utc)
         return eclipse_duration(beta, self.period)
 
-    def passes_over(self, location, when_utc, limit_date=None, max_elevation_gt=0, aos_at_dg=0):
-        return LocationPredictor(location, self, when_utc, limit_date,
-                                 max_elevation_gt, aos_at_dg)
+    def passes_over(self, location, when_utc, limit_date=None, max_elevation_gt=0, aos_at_dg=0,
+                    location_predictor_class=LocationPredictor):
+        return location_predictor_class(location, self, when_utc, limit_date,
+                                        max_elevation_gt, aos_at_dg)
 
     def get_next_pass(self, location, when_utc=None, max_elevation_gt=5,
-                      aos_at_dg=0, limit_date=None):
+                      aos_at_dg=0, limit_date=None,
+                      location_predictor_class=LocationPredictor):
         """Return a PredictedPass instance with the data of the next pass over the given location
 
         location_llh: point on Earth we want to see from the satellite.
@@ -208,7 +210,8 @@ class CartesianPredictor(Predictor):
 
         for pass_ in self.passes_over(location, when_utc, limit_date,
                                       max_elevation_gt=max_elevation_gt,
-                                      aos_at_dg=aos_at_dg):
+                                      aos_at_dg=aos_at_dg,
+                                      location_predictor_class=location_predictor_class):
             return pass_
         else:
             raise NotReachable('Propagation limit date exceeded')

--- a/orbit_predictor/predictors/base.py
+++ b/orbit_predictor/predictors/base.py
@@ -365,15 +365,7 @@ class LocationPredictor:
     """
 
     def __init__(self, location, predictor, start_date, limit_date=None,
-                 max_elevation_gt=0, aos_at_dg=0, *, propagator=None):
-        if propagator is not None:
-            warnings.warn(
-                "propagator parameter was renamed to predictor "
-                "and will be removed in a future release",
-                DeprecationWarning
-            )
-            predictor = propagator
-
+                 max_elevation_gt=0, aos_at_dg=0):
         self.location = location
         self.predictor = predictor
         self.start_date = start_date
@@ -381,15 +373,6 @@ class LocationPredictor:
 
         self.max_elevation_gt = radians(max([max_elevation_gt, aos_at_dg]))
         self.aos_at = radians(aos_at_dg)
-
-    @property
-    def propagator(self):
-        warnings.warn(
-            "propagator parameter was renamed to predictor "
-            "and will be removed in a future release",
-            DeprecationWarning
-        )
-        return self.predictor
 
     def __iter__(self):
         """Returns one pass each time"""

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -5,6 +5,7 @@ import warnings
 
 try:
     from scipy.optimize import root_scalar, minimize_scalar
+    from ._minimize import minimize_scalar_bounded_alt
 except ImportError:
     warnings.warn(
         "scipy module was not found, some features may not work properly",
@@ -21,8 +22,6 @@ from orbit_predictor.utils import (
     vector_norm,
     orbital_period,
 )
-
-from ._minimize import minimize_scalar_bounded_alt
 
 ONE_SECOND = dt.timedelta(seconds=1)
 

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -1,0 +1,275 @@
+import datetime as dt
+import logging
+from math import pi, acos, degrees, radians
+import warnings
+
+from orbit_predictor.exceptions import PropagationError
+from orbit_predictor.utils import (
+    cross_product,
+    dot_product,
+    reify,
+    vector_diff,
+    vector_norm,
+)
+
+ONE_SECOND = dt.timedelta(seconds=1)
+
+logger = logging.getLogger(__name__)
+
+
+def round_datetime(dt_):
+    return dt_
+
+
+class LocationPredictor:
+    """Predicts passes over a given location
+    Exposes an iterable interface
+    """
+
+    def __init__(self, location, predictor, start_date, limit_date=None,
+                 max_elevation_gt=0, aos_at_dg=0):
+        self.location = location
+        self.predictor = predictor
+        self.start_date = start_date
+        self.limit_date = limit_date
+
+        self.max_elevation_gt = radians(max([max_elevation_gt, aos_at_dg]))
+        self.aos_at = radians(aos_at_dg)
+
+    def __iter__(self):
+        """Returns one pass each time"""
+        current_date = self.start_date
+        while True:
+            if self.is_ascending(current_date):
+                # we need a descending point
+                ascending_date = current_date
+                descending_date = self._find_nearest_descending(ascending_date)
+                pass_ = self._refine_pass(ascending_date, descending_date)
+                if pass_.valid:
+                    if self.limit_date is not None and pass_.aos > self.limit_date:
+                        break
+                    yield self._build_predicted_pass(pass_)
+
+                if self.limit_date is not None and current_date > self.limit_date:
+                    break
+
+                current_date = pass_.tca + self._orbit_step(0.6)
+
+            else:
+                current_date = self._find_nearest_ascending(current_date)
+
+    def _build_predicted_pass(self, accuratepass):
+        """Returns a classic predicted pass"""
+        tca_position = self.predictor.get_position(accuratepass.tca)
+
+        return PredictedPass(self.location, self.predictor.sate_id,
+                             max_elevation_deg=accuratepass.max_elevation_deg,
+                             aos=accuratepass.aos,
+                             los=accuratepass.los,
+                             duration_s=accuratepass.duration.total_seconds(),
+                             max_elevation_position=tca_position,
+                             max_elevation_date=accuratepass.tca,
+                             )
+
+    def _find_nearest_descending(self, ascending_date):
+        for candidate in self._sample_points(ascending_date):
+            if not self.is_ascending(candidate):
+                return candidate
+        else:
+            logger.error('Could not find a descending pass over %s start date: %s - TLE: %s',
+                         self.location, ascending_date, self.predictor.tle)
+            raise PropagationError("Can not find an descending phase")
+
+    def _find_nearest_ascending(self, descending_date):
+        for candidate in self._sample_points(descending_date):
+            if self.is_ascending(candidate):
+                return candidate
+        else:
+            logger.error('Could not find an ascending pass over %s start date: %s - TLE: %s',
+                         self.location, descending_date, self.predictor.tle)
+            raise PropagationError('Can not find an ascending phase')
+
+    def _sample_points(self, date):
+        """Helper method to found ascending or descending phases of elevation"""
+        start = date
+        end = date + self._orbit_step(0.99)
+        mid = self.midpoint(start, end)
+        mid_right = self.midpoint(mid, end)
+        mid_left = self.midpoint(start, mid)
+
+        return [end, mid, mid_right, mid_left]
+
+    def _refine_pass(self, ascending_date, descending_date):
+        tca = self._find_tca(ascending_date, descending_date)
+        elevation = self._elevation_at(tca)
+
+        if elevation > self.max_elevation_gt:
+            aos = self._find_aos(tca)
+            los = self._find_los(tca)
+        else:
+            aos = los = None
+
+        return AccuratePredictedPass(aos, tca, los, elevation)
+
+    def _find_tca(self, ascending_date, descending_date):
+        while not self._precision_reached(ascending_date, descending_date):
+            midpoint = self.midpoint(ascending_date, descending_date)
+            if self.is_ascending(midpoint):
+                ascending_date = midpoint
+            else:
+                descending_date = midpoint
+
+        return ascending_date
+
+    def _precision_reached(self, start, end):
+        # TODO: Allow the precision to change from the outside
+        return end - start <= ONE_SECOND
+
+    @staticmethod
+    def midpoint(start, end):
+        """Returns the midpoint between two dates"""
+        return start + (end - start) / 2
+
+    def _elevation_at(self, when_utc):
+        position = self.predictor.get_only_position(when_utc)
+        return self.location.elevation_for(position)
+
+    def is_passing(self, when_utc):
+        """Returns a boolean indicating if satellite is actually visible"""
+        return bool(self._elevation_at(when_utc))
+
+    def is_ascending(self, when_utc):
+        """Check is elevation is ascending or descending on a given point"""
+        elevation = self._elevation_at(when_utc)
+        next_elevation = self._elevation_at(when_utc + ONE_SECOND)
+        return elevation <= next_elevation
+
+    def _orbit_step(self, size):
+        """Returns a time step, that will make the satellite advance a given number of orbits"""
+        step_in_radians = size * 2 * pi
+        seconds = (step_in_radians / self.predictor.mean_motion) * 60
+        return dt.timedelta(seconds=seconds)
+
+    def _find_aos(self, tca):
+        end = tca
+        start = tca - self._orbit_step(0.34)  # On third of the orbit
+        elevation = self._elevation_at(start)
+        assert elevation < 0
+        while not self._precision_reached(start, end):
+            midpoint = self.midpoint(start, end)
+            elevation = self._elevation_at(midpoint)
+            if elevation < self.aos_at:
+                start = midpoint
+            else:
+                end = midpoint
+        return end
+
+    def _find_los(self, tca):
+        start = tca
+        end = tca + self._orbit_step(0.34)
+        while not self._precision_reached(start, end):
+            midpoint = self.midpoint(start, end)
+            elevation = self._elevation_at(midpoint)
+
+            if elevation < self.aos_at:
+                end = midpoint
+            else:
+                start = midpoint
+
+        return start
+
+
+class PredictedPass:
+    def __init__(self, location, sate_id,
+                 max_elevation_deg,
+                 aos, los, duration_s,
+                 max_elevation_position=None,
+                 max_elevation_date=None):
+        self.location = location
+        self.sate_id = sate_id
+        self.max_elevation_position = max_elevation_position
+        self.max_elevation_date = max_elevation_date
+        self.max_elevation_deg = max_elevation_deg
+        self.aos = aos
+        self.los = los
+        self.duration_s = duration_s
+
+    @property
+    def midpoint(self):
+        """Returns a datetime of the midpoint of the pass"""
+        return self.aos + (self.los - self.aos) / 2
+
+    def __repr__(self):
+        return "<PredictedPass {} over {} on {}>".format(self.sate_id, self.location, self.aos)
+
+    def __eq__(self, other):
+        return all([issubclass(other.__class__, PredictedPass),
+                    self.location == other.location,
+                    self.sate_id == other.sate_id,
+                    self.max_elevation_position == other.max_elevation_position,
+                    self.max_elevation_date == other.max_elevation_date,
+                    self.max_elevation_deg == other.max_elevation_deg,
+                    self.aos == other.aos,
+                    self.los == other.los,
+                    self.duration_s == other.duration_s])
+
+    def get_off_nadir_angle(self):
+        warnings.warn("This method is deprecated!", DeprecationWarning)
+        return self.off_nadir_deg
+
+    @reify
+    def off_nadir_deg(self):
+        """Computes off-nadir angle calculation
+
+        Given satellite position ``sate_pos``, velocity ``sate_vel``, and
+        location ``target`` in a common frame, off-nadir angle ``off_nadir_angle``
+        is given by:
+            t2b = sate_pos - target
+            cos(off_nadir_angle) =     (sate_pos  · t2b)     # Vectorial dot product
+                                    _______________________
+                                    || sate_pos || || t2b||
+
+        Sign for the rotation is calculated this way
+
+        cross = target ⨯ sate_pos
+        sign =   cross · sate_vel
+               ____________________
+               | cross · sate_vel |
+        """
+        sate_pos = self.max_elevation_position.position_ecef
+        sate_vel = self.max_elevation_position.velocity_ecef
+        target = self.location.position_ecef
+        t2b = vector_diff(sate_pos, target)
+        angle = acos(
+            dot_product(sate_pos, t2b) / (vector_norm(sate_pos) * vector_norm(t2b))
+        )
+
+        cross = cross_product(target, sate_pos)
+        dot = dot_product(cross, sate_vel)
+        try:
+            sign = dot / abs(dot)
+        except ZeroDivisionError:
+            sign = 1
+
+        return degrees(angle) * sign
+
+
+class AccuratePredictedPass:
+
+    def __init__(self, aos, tca, los, max_elevation):
+        self.aos = round_datetime(aos) if aos is not None else None
+        self.tca = round_datetime(tca)
+        self.los = round_datetime(los) if los is not None else None
+        self.max_elevation = max_elevation
+
+    @property
+    def valid(self):
+        return self.max_elevation > 0 and self.aos is not None and self.los is not None
+
+    @reify
+    def max_elevation_deg(self):
+        return degrees(self.max_elevation)
+
+    @reify
+    def duration(self):
+        return self.los - self.aos

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -232,13 +232,14 @@ class SmartLocationPredictor(BaseLocationPredictor):
         period_s = orbital_period(self.predictor.mean_motion) * 60
 
         # Find date for maximum elevation within the next orbital period
-        t_tca = minimize_scalar(
+        res_tca = minimize_scalar(
             lambda t: -elevation(t), bounds=(0, period_s),
             method=minimize_scalar_bounded_alt,
             options=dict(xatol=atol),
-        ).x
+        )
+        t_tca = res_tca.x
         tca = start_date + dt.timedelta(seconds=t_tca)
-        max_elevation = self._elevation_at(tca)
+        max_elevation = -res_tca.fun
         if max_elevation < self.max_elevation_gt:
             return False, None, tca, start_date + dt.timedelta(seconds=period_s), max_elevation
 

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -21,10 +21,7 @@ def round_datetime(dt_):
     return dt_
 
 
-class LocationPredictor:
-    """Predicts passes over a given location
-    Exposes an iterable interface
-    """
+class BaseLocationPredictor:
 
     def __init__(self, location, predictor, start_date, limit_date=None,
                  max_elevation_gt=0, aos_at_dg=0):
@@ -37,6 +34,19 @@ class LocationPredictor:
         self.aos_at = radians(aos_at_dg)
 
     def __iter__(self):
+        yield from self.iter_passes()
+
+    def iter_passes(self):
+        """Yields passes"""
+        raise NotImplementedError
+
+
+class LocationPredictor(BaseLocationPredictor):
+    """Predicts passes over a given location
+    Exposes an iterable interface
+    """
+
+    def iter_passes(self):
         """Returns one pass each time"""
         current_date = self.start_date
         while True:

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -234,6 +234,7 @@ class SmartLocationPredictor(BaseLocationPredictor):
         period_s = orbital_period(self.predictor.mean_motion) * 60
 
         # Find date for maximum elevation within the next orbital period
+        # NOTE: This is the most expensive operation
         res_tca = minimize_scalar(
             lambda t: -elevation(t), bounds=(0, period_s),
             method=minimize_scalar_bounded_alt,
@@ -245,7 +246,7 @@ class SmartLocationPredictor(BaseLocationPredictor):
         if max_elevation < self.max_elevation_gt:
             return False, None, tca, start_date + dt.timedelta(seconds=period_s), max_elevation
 
-        # Find AOS (that it might be past the start date)
+        # Find AOS
         try:
             if self.aos_at < start_elevation:
                 # AOS is past the start date
@@ -264,7 +265,7 @@ class SmartLocationPredictor(BaseLocationPredictor):
         # Ensure location is visible at AOS by adding atol
         aos = start_date + dt.timedelta(seconds=t_aos + self.tolerance_s)
 
-        # LOS must be between TCA and an elapsed time around TCA + (TCA - AOS)
+        # LOS must be between TCA and an elapsed time around (TCA - AOS)
         try:
             t_los = root_scalar(
                 lambda t: elevation(t) - self.aos_at,

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -22,6 +22,8 @@ from orbit_predictor.utils import (
     orbital_period,
 )
 
+from ._minimize import minimize_scalar_bounded_alt
+
 ONE_SECOND = dt.timedelta(seconds=1)
 
 logger = logging.getLogger(__name__)
@@ -231,7 +233,8 @@ class SmartLocationPredictor(BaseLocationPredictor):
 
         # Find date for maximum elevation within the next orbital period
         t_tca = minimize_scalar(
-            lambda t: -elevation(t), bounds=(0, period_s), method="bounded",
+            lambda t: -elevation(t), bounds=(0, period_s),
+            method=minimize_scalar_bounded_alt,
             options=dict(xatol=atol),
         ).x
         tca = start_date + dt.timedelta(seconds=t_tca)

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -40,7 +40,7 @@ class LocationPredictor:
         """Returns one pass each time"""
         current_date = self.start_date
         while True:
-            if self.is_ascending(current_date):
+            if self._is_ascending(current_date):
                 # we need a descending point
                 ascending_date = current_date
                 descending_date = self._find_nearest_descending(ascending_date)
@@ -73,7 +73,7 @@ class LocationPredictor:
 
     def _find_nearest_descending(self, ascending_date):
         for candidate in self._sample_points(ascending_date):
-            if not self.is_ascending(candidate):
+            if not self._is_ascending(candidate):
                 return candidate
         else:
             logger.error('Could not find a descending pass over %s start date: %s - TLE: %s',
@@ -82,7 +82,7 @@ class LocationPredictor:
 
     def _find_nearest_ascending(self, descending_date):
         for candidate in self._sample_points(descending_date):
-            if self.is_ascending(candidate):
+            if self._is_ascending(candidate):
                 return candidate
         else:
             logger.error('Could not find an ascending pass over %s start date: %s - TLE: %s',
@@ -114,7 +114,7 @@ class LocationPredictor:
     def _find_tca(self, ascending_date, descending_date):
         while not self._precision_reached(ascending_date, descending_date):
             midpoint = self.midpoint(ascending_date, descending_date)
-            if self.is_ascending(midpoint):
+            if self._is_ascending(midpoint):
                 ascending_date = midpoint
             else:
                 descending_date = midpoint
@@ -134,11 +134,7 @@ class LocationPredictor:
         position = self.predictor.get_only_position(when_utc)
         return self.location.elevation_for(position)
 
-    def is_passing(self, when_utc):
-        """Returns a boolean indicating if satellite is actually visible"""
-        return bool(self._elevation_at(when_utc))
-
-    def is_ascending(self, when_utc):
+    def _is_ascending(self, when_utc):
         """Check is elevation is ascending or descending on a given point"""
         elevation = self._elevation_at(when_utc)
         next_elevation = self._elevation_at(when_utc + ONE_SECOND)

--- a/orbit_predictor/utils.py
+++ b/orbit_predictor/utils.py
@@ -465,6 +465,11 @@ def mean_motion(sma_km):
     return sqrt(MU_E / sma_km ** 3)  # rad / s
 
 
+def orbital_period(mean_motion):
+    """Orbital period, in minutes"""
+    return 1 / mean_motion * 2 * pi
+
+
 class reify:
     """
     Use as a class method decorator.  It operates almost exactly like the

--- a/tests/test_accurate_predictor.py
+++ b/tests/test_accurate_predictor.py
@@ -22,6 +22,7 @@
 
 import datetime as dt
 from unittest import TestCase, mock
+import sys
 
 import logassert
 from hypothesis import example, given, settings
@@ -272,6 +273,7 @@ class SkippedPassesRegressionTests(TestCase):
 
         assert predicted_passes
 
+    @pytest.mark.skipif(sys.version_info < (3, 5), reason="Not installing SciPy in Python 3.4")
     def test_pass_is_not_skipped_smart(self):
         loc = Location(
             name="loc",

--- a/tests/test_accurate_predictor.py
+++ b/tests/test_accurate_predictor.py
@@ -213,7 +213,7 @@ class AccuratePredictorCalculationErrorTests(TestCase):
         # Predictor
         self.predictor = TLEPredictor(BUGSAT_SATE_ID, self.db)
         self.is_ascending_mock = self._patch(
-            'orbit_predictor.predictors.base.LocationPredictor.is_ascending')
+            'orbit_predictor.predictors.base.LocationPredictor._is_ascending')
         self.start = dt.datetime(2017, 3, 6, 7, 51)
         logassert.setup(self,  'orbit_predictor.predictors.base')
 

--- a/tests/test_accurate_predictor.py
+++ b/tests/test_accurate_predictor.py
@@ -225,14 +225,16 @@ class AccuratePredictorCalculationErrorTests(TestCase):
     def test_ascending_failure(self):
         self.is_ascending_mock.return_value = False
         with self.assertRaises(PropagationError):
-            self.predictor.get_next_pass(ARG, self.start)
+            self.predictor.get_next_pass(ARG, self.start,
+                                         location_predictor_class=LocationPredictor)
 
         self.assertLoggedError(str(ARG), str(self.start), *BUGSAT1_TLE_LINES)
 
     def test_descending_failure(self):
         self.is_ascending_mock.return_value = True
         with self.assertRaises(PropagationError):
-            self.predictor.get_next_pass(ARG, self.start)
+            self.predictor.get_next_pass(ARG, self.start,
+                                         location_predictor_class=LocationPredictor)
 
         self.assertLoggedError(str(ARG), str(self.start), *BUGSAT1_TLE_LINES)
 

--- a/tests/test_accurate_predictor.py
+++ b/tests/test_accurate_predictor.py
@@ -217,7 +217,7 @@ class AccuratePredictorCalculationErrorTests(TestCase):
         self.is_ascending_mock = self._patch(
             'orbit_predictor.predictors.base.LocationPredictor._is_ascending')
         self.start = dt.datetime(2017, 3, 6, 7, 51)
-        logassert.setup(self,  'orbit_predictor.predictors.base')
+        logassert.setup(self,  'orbit_predictor.predictors.pass_iterators')
 
     def _patch(self, *args,  **kwargs):
         patcher = mock.patch(*args, **kwargs)


### PR DESCRIPTION
Fixes #99 by adding a more robust location predictor. The code is simpler and easier to understand by leveraging SciPy minimization and root finding methods when available.

_**Edit**: Performance regression described below has been addressed already, see comments below_

The problem is that the current implementation, as we lose control over function evaluations, the propagator ends up being called more times and the method is around 3x-4x slower:

```
In [7]: !cat perfy.py                                      
# coding: utf-8
SATE_ID = '41558U'  # newsat 2
LINES = (
    '1 41558U 16033C   17065.21129769  .00002236  00000-0  88307-4 0  9995',
    '2 41558  97.4729 144.7611 0014207  16.2820 343.8872 15.26500433 42718',
)
from orbit_predictor.predictors.base import ONE_SECOND
from orbit_predictor.exceptions import PropagationError
from orbit_predictor.locations import Location, ARG
from orbit_predictor.predictors import TLEPredictor
from orbit_predictor.predictors.pass_iterators import SmartLocationPredictor, LocationPredictor
from orbit_predictor.sources import MemoryTLESource
db = MemoryTLESource()
import datetime as dt
start = dt.datetime(2017, 3, 6, 7, 51)
db.add_tle(SATE_ID, LINES, start)
predictor = TLEPredictor(SATE_ID, db)
end = start + dt.timedelta(days=5)
location = Location('bad-case-1', 11.937501570612568,
                    -55.35189435098657, 1780.674044538666)
list(predictor.passes_over(location, start, end, location_predictor_class=LocationPredictor))
list(predictor.passes_over(location, start, end, location_predictor_class=SmartLocationPredictor))
get_ipython().run_line_magic('timeit', 'list(predictor.passes_over(location, start, end, location_predictor_class=LocationPredictor))')
get_ipython().run_line_magic('timeit', 'list(predictor.passes_over(location, start, end, location_predictor_class=SmartLocationPredictor))')

In [8]: %run perfy.py                                      
8.21 ms ± 653 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
36.3 ms ± 293 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

therefore the "smart" in `SmartLocationPrediction` is an aspiration rather than a reality :wink: 