### PR TITLE
Fix wrong pass in SmartLocationPredictor

### DIFF
--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -3,6 +3,7 @@ import logging
 from math import pi, acos, degrees, radians
 import warnings
 
+import numpy as np
 try:
     from scipy.signal import find_peaks
     from scipy.optimize import root_scalar, minimize_scalar
@@ -202,10 +203,8 @@ class SmartLocationPredictor(BaseLocationPredictor):
 
     def iter_passes(self):
         # Explore all values of t every 3 minutes
-        t_values = list(range(0, int((self.limit_date - self.start_date).total_seconds()), 180))
-        elev_values = []
-        for delta_seconds in t_values:
-            elev_values.append(self._elevation(delta_seconds))
+        t_values = np.arange(0, (self.limit_date - self.start_date).total_seconds(), 180)
+        elev_values = np.array([self._elevation(delta_seconds) for delta_seconds in t_values])
 
         peaks_idx, _ = find_peaks(elev_values)
 

--- a/orbit_predictor/predictors/pass_iterators.py
+++ b/orbit_predictor/predictors/pass_iterators.py
@@ -57,8 +57,12 @@ class BaseLocationPredictor:
 
 
 class LocationPredictor(BaseLocationPredictor):
-    """Predicts passes over a given location
-    Exposes an iterable interface
+    """Predicts passes over a given location.
+
+    Exposes an iterable interface.
+    Notice that this algorithm is not fully exhaustive,
+    see https://github.com/satellogic/orbit-predictor/issues/99 for details.
+
     """
 
     def iter_passes(self):
@@ -200,6 +204,14 @@ class LocationPredictor(BaseLocationPredictor):
 
 
 class SmartLocationPredictor(BaseLocationPredictor):
+    """Predicts passes over a given location using a different algorithm.
+
+    This uses a sampling interval of 3 minutes,
+    which seems like a good compromise for Low-Earth Orbits.
+    However, this means that, under certain circumstances, passes
+    shorter than this duration could theoretically be missed.
+
+    """
 
     def iter_passes(self):
         # Explore all values of t every 3 minutes
@@ -239,6 +251,7 @@ class SmartLocationPredictor(BaseLocationPredictor):
             lambda t: self._elevation(t) - self.aos_at,
             bracket=(t_approximate_tca - period_s / 2, t_approximate_tca),
             xtol=self.tolerance_s,
+            method="brentq",
         ).root
         aos = self.start_date + dt.timedelta(seconds=t_aos)
 
@@ -247,6 +260,7 @@ class SmartLocationPredictor(BaseLocationPredictor):
             lambda t: self._elevation(t) - self.aos_at,
             bracket=(t_approximate_tca, t_approximate_tca + period_s / 2),
             xtol=self.tolerance_s,
+            method="brentq",
         ).root
         los = self.start_date + dt.timedelta(seconds=t_los)
 

--- a/tests/test_accurate_predictor.py
+++ b/tests/test_accurate_predictor.py
@@ -297,7 +297,7 @@ class SkippedPassesRegressionTests(TestCase):
 
 
 class LOSComputationRegressionTests(TestCase):
-    """Check that we the LOS is computed correctly"""
+    """Check that the LOS is computed correctly"""
     # See https://github.com/satellogic/orbit-predictor/issues/104
 
     def setUp(self):


### PR DESCRIPTION
Alternative to #114 to fix #113.

~The code is now super ugly and I removed all the comments, but it _seems_ to work. Tomorrow I will refine and bechmark it.~

Slightly slower than #100, see `perfy.py` there:

```
In [1]: %run perfy.py                                                                                                                                                                                                                         
6.33 ms ± 57.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
7.94 ms ± 293 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

A granularity of 3 minutes sounds like a reasonable value, I think anything larger than that risks missing passes.

This ended up being not very sophisticated (sampling the elevation) but at least works.