### PR TITLE
Fix failing pipelines 

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.4, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.4.4, 3.5.10, 3.6.15, 3.7.13, 3.8.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.4.4, 3.5.10, 3.6.15, 3.7.13, 3.8.13]
+        python-version: [3.4.10, 3.5.10, 3.6.15, 3.7.13, 3.8.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.4.10, 3.5.10, 3.6.15, 3.7.13, 3.8.13]
+        python-version: [3.4, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "scipy>=0.16",
         ],
         "dev": [
-            "hypothesis<4.0.0",
+            "hypothesis<5.0.0",
             "flake8",
             "hypothesis[datetime]",
             "mock",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "scipy>=0.16",
         ],
         "dev": [
-            "hypothesis",
+            "hypothesis<4.0.0",
             "flake8",
             "hypothesis[datetime]",
             "mock",

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -70,7 +70,7 @@ def test_get_normal_vector_zero_inclination_always_z_aligned(predictor, when_utc
     assert normal_vector[2] == 1
 
 
-@settings(suppress_health_check=(HealthCheck.function_scoped_fixture))
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture, ))
 @given(datetimes())
 def test_get_beta_always_between_m_90_and_90(non_sun_synchronous, when_utc):
     assert -90 <= non_sun_synchronous.get_beta(when_utc) <= 90

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import importlib.util
 
-from hypothesis import given, settings, HealthCheck
+from hypothesis import given
 from hypothesis.strategies import datetimes, composite, floats
 import pytest
 
@@ -70,7 +70,6 @@ def test_get_normal_vector_zero_inclination_always_z_aligned(predictor, when_utc
     assert normal_vector[2] == 1
 
 
-@settings(suppress_health_check=(HealthCheck.function_scoped_fixture, ))
 @given(datetimes())
 def test_get_beta_always_between_m_90_and_90(non_sun_synchronous, when_utc):
     assert -90 <= non_sun_synchronous.get_beta(when_utc) <= 90

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import importlib.util
 
-from hypothesis import given
+from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import datetimes, composite, floats
 import pytest
 
@@ -70,6 +70,7 @@ def test_get_normal_vector_zero_inclination_always_z_aligned(predictor, when_utc
     assert normal_vector[2] == 1
 
 
+@settings(suppress_health_check=(HealthCheck.function_scoped_fixture))
 @given(datetimes())
 def test_get_beta_always_between_m_90_and_90(non_sun_synchronous, when_utc):
     assert -90 <= non_sun_synchronous.get_beta(when_utc) <= 90


### PR DESCRIPTION
This fixes two issues that were prevent pipelines from running: 
- Use ubuntu 18.04 in pipelines so we can test python 3.4 (no longer present in ubuntu-latest), which we need to support.
- Fix new failing health check in hypothesis tests by requiring an old version of hypothesis.

Regarding the old version of hypothesis:

The newer versions require adding a specific health check to a skip list, otherwise many tests fail. But those hypothesis versions don't run on python 3.4, so the pipelines end up using an older hypothesis depending on the python version... and the code to fix the new versions, fails in the old versions. 
If we use the newest hypothesis on each python version, the code will fail on some and run on others. To ensure it runs on all, we need to pin hypothesis instead to an old enough version of the lib :(