### PR TITLE
Add missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pytest
 pytest-cov==2.5.0
 requests>=2.9.1
 sgp4>=1.4
+numpy
+scipy


### PR DESCRIPTION
Using `./test` to run tests fails due to missing requirements in `requirements.txt`

This pull request fixes the issue