### PR TITLE
Fix get sun

### DIFF
--- a/orbit_predictor/utils.py
+++ b/orbit_predictor/utils.py
@@ -297,9 +297,10 @@ def _sun_eci(w, M, L, eccentricity, oblecl):
     zeclip = 0.0
 
     # rotate these coordinates to equatorial rectangular coordinates
+    # (skip the zeclip portion since zeclip == 0)
     xequat = xeclip
-    yequat = yeclip * cos_d(oblecl) + zeclip * sin_d(oblecl)
-    zequat = yeclip * sin_d(23.4406) + zeclip * cos_d(oblecl)
+    yequat = yeclip * cos_d(oblecl)
+    zequat = yeclip * sin_d(oblecl)
 
     return [xequat, yequat, zequat]
 

--- a/orbit_predictor/utils.py
+++ b/orbit_predictor/utils.py
@@ -277,6 +277,10 @@ def _sun_mean_ecliptic_elements(t_ut1):
 
 
 def _sun_eci(w, M, L, eccentricity, oblecl):
+    # Original algorithm seems to come from http://www.stargazing.net/kepler/altaz.html
+    # Current code seems to come from
+    # https://la.mathworks.com/matlabcentral/fileexchange/23051-vectorized-solar-azimuth-and-elevation-estimation
+
     # auxiliary angle
     auxiliary_angle = M + degrees(eccentricity * sin_d(M) * (1 + eccentricity * cos_d(M)))
 
@@ -297,7 +301,9 @@ def _sun_eci(w, M, L, eccentricity, oblecl):
     zeclip = 0.0
 
     # rotate these coordinates to equatorial rectangular coordinates
-    # (skip the zeclip portion since zeclip == 0)
+    # There are two differences wrt matlab original code:
+    # 1. fix a hardcoded 23.4406 oblecl
+    # 2. skip the zeclip portion (since zeclip == 0)
     xequat = xeclip
     yequat = yeclip * cos_d(oblecl)
     zequat = yeclip * sin_d(oblecl)


### PR DESCRIPTION
The original code in `get_sun` seems to come from https://la.mathworks.com/matlabcentral/fileexchange/23051-vectorized-solar-azimuth-and-elevation-estimation

There is a bug there with a hardcoded `oblecl` as `23.4406`. The difference is really minuscule, it affects the 4th significant digit.
There is a second bug with a sign, but it is not noticeable since the corresponding term is always 0

This PR fixes both bugs.