### PR TITLE
Fix elevation_for math domain problem

### DIFF
--- a/orbit_predictor/locations.py
+++ b/orbit_predictor/locations.py
@@ -30,6 +30,11 @@ from orbit_predictor import coordinate_systems
 from orbit_predictor.utils import reify, sun_azimuth_elevation
 
 
+def clamp(val, min_value, max_value):
+    """Clamp a value between min_value and max_value."""
+    return max(min(val, max_value), min_value)
+
+
 class Location:
     def __init__(self, name, latitude_deg, longitude_deg, elevation_m):
         """Location.
@@ -107,8 +112,9 @@ class Location:
         top_z = (a * rx) + (b * ry) + (c * rz)
 
         range_sat = sqrt((rx * rx) + (ry * ry) + (rz * rz))
-
-        return asin(top_z / range_sat)
+        # avoid float errors
+        sin_elev = clamp(top_z / range_sat, -1, 1)
+        return asin(sin_elev)
 
     def get_azimuth_elev(self, position):
         """Return azimuth and elevation of position_ecef from the current Location instance."""

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -112,3 +112,15 @@ class LocationTestCase(unittest.TestCase):
         # https://github.com/satellogic/orbit-predictor/issues/52
         l1 = Location(latitude_deg=1, longitude_deg=2, elevation_m=3, name="location1")
         l1.sun_elevation_on_earth()
+
+    def test_elevation_for(self):
+        # choose a satellite position and check that the elevation from the point
+        # right below it is 90 degrees
+        date = dt.datetime.strptime("2014-10-21 22:47:29.147740", '%Y-%m-%d %H:%M:%S.%f')
+        position = self.predictor.get_position(date)
+        location = Location(latitude_deg=position.position_llh[0],
+                            longitude_deg=position.position_llh[1],
+                            elevation_m=0,
+                            name="location1")
+        elevation = location.elevation_for(position.position_ecef)
+        self.assertAlmostEqual(degrees(elevation), 90.0, delta=0.1)


### PR DESCRIPTION
if the position of the object in `Location.elevation_for()` call is right above it, the method sometimes raises an exception because it tries to compute `asin(1 + epsilon)` because of floating errors.